### PR TITLE
Fixed file path in README for ARKitFaceFilterDemo initial clone operation.

### DIFF
--- a/examples/ARKitFaceFilterDemo/README.md
+++ b/examples/ARKitFaceFilterDemo/README.md
@@ -23,7 +23,7 @@ Using ARKit's face detection and the SVRF API, you can apply 3D face filters to 
 Clone the repository and navigate to the example.
 
 ```bash
-git clone https://github.com/SVRF/svrf-api.git && cd ./svrf-api/examples/ARKitFaceDemo
+git clone https://github.com/SVRF/svrf-api.git && cd ./svrf-api/examples/ARKitFaceFilterDemo
 ```
 
 Install the dependencies using [CocoaPods][].


### PR DESCRIPTION
# Pull Request

## Description

- The `README` had an incorrect path in the "git clone" script to quickly get started with the project (`cd ./svrf-api/examples/ARKitFaceDemo` should be `cd ./svrf-api/examples/ARKitFaceFilterDemo`).

### Motivation and Context

N/A

### Screenshots

N/A

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [x] Maintenance

### Checklist

- [x] Documentation
- [x] Tests
